### PR TITLE
enhancement(cdk#2) [CDK - Pawn movement] Add pawn route strategies

### DIFF
--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CaptureAndMovementAdapter.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CaptureAndMovementAdapter.java
@@ -1,0 +1,51 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Set;
+
+public class CaptureAndMovementAdapter implements Movement {
+  private final RouteStrategy capture;
+  private final RouteStrategy movement;
+
+  public CaptureAndMovementAdapter(RouteStrategy capture, RouteStrategy movement) {
+    this.capture = capture;
+    this.movement = movement;
+  }
+
+  @Override
+  public MovementOutcome execute(Coordinate from, Coordinate target) {
+    final var result = MovementOutcome.builder();
+
+    boolean controllable = existsRelation(from, target);
+    result.executed(controllable);
+    if (controllable) {
+      result.position(target);
+    }
+
+    if (capture.existsRelation(from, target)) {
+      final Set<Coordinate> targets = calculatePossibleCaptures(target);
+      result.capture(targets);
+    }
+
+    return result.build();
+  }
+
+  @Override
+  public boolean canCapture(Coordinate from, Coordinate target) {
+    return this.capture.existsRelation(from, target);
+  }
+
+  @Override
+  public Set<Coordinate> calculatePossibleCaptures(Coordinate from) {
+    return this.capture.calculateAvailable(from);
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return this.movement.existsRelation(from, target);
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    return this.movement.calculateAvailable(from);
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CaptureOnTargetMovement.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CaptureOnTargetMovement.java
@@ -1,0 +1,44 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Set;
+
+public class CaptureOnTargetMovement implements Movement {
+  private final RouteStrategy movement;
+
+  public CaptureOnTargetMovement(RouteStrategy movement) {
+    this.movement = movement;
+  }
+
+  @Override
+  public MovementOutcome execute(Coordinate from, Coordinate target) {
+    final MovementOutcome.MovementOutcomeBuilder result = MovementOutcome.builder();
+
+    boolean controllable = existsRelation(from, target);
+    result.executed(controllable);
+    if (controllable) {
+      result.position(target).capture(target);
+    }
+
+    return result.build();
+  }
+
+  @Override
+  public boolean canCapture(Coordinate from, Coordinate target) {
+    return existsRelation(from, target);
+  }
+
+  @Override
+  public Set<Coordinate> calculatePossibleCaptures(Coordinate from) {
+    return this.movement.calculateAvailable(from);
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return this.movement.existsRelation(from, target);
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    return this.movement.calculateAvailable(from);
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CapturelessMovement.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/CapturelessMovement.java
@@ -1,0 +1,45 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class CapturelessMovement implements Movement {
+  private final RouteStrategy movement;
+
+  public CapturelessMovement(RouteStrategy movement) {
+    this.movement = movement;
+  }
+
+  @Override
+  public MovementOutcome execute(Coordinate from, Coordinate target) {
+    final MovementOutcome.MovementOutcomeBuilder result = MovementOutcome.builder();
+
+    boolean controllable = existsRelation(from, target);
+    result.executed(controllable);
+    if (controllable) {
+      result.position(target);
+    }
+
+    return result.build();
+  }
+
+  @Override
+  public boolean canCapture(Coordinate from, Coordinate target) {
+    return false;
+  }
+
+  @Override
+  public Set<Coordinate> calculatePossibleCaptures(Coordinate from) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return this.movement.existsRelation(from, target);
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    return this.movement.calculateAvailable(from);
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/EnPassantRouteStrategy.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/EnPassantRouteStrategy.java
@@ -1,0 +1,61 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * This class is a specialization of {@code DirectionalDeltaRouteStrategy} that defines the behavior
+ * between coordinates for the 'en passant' move.
+ *
+ * <p>The 'en passant move' in chess is a special pawn capture that can occur when a pawn moves two
+ * squares forward from its starting position and lands beside an opponent's pawn. This capture must
+ * happen immediately after the two-square move, or the opportunity is lost.
+ *
+ * <p>Example: - White pawn on e5. - On black turn, black pawn is moved from d7 to d5 (two squares
+ * forward). - White has option to capture the black pawn en passant, moving pawn from e5 to d6,
+ * capturing the black pawn as if it had moved only one square forward.
+ *
+ * @author sigur
+ * @see DirectionalDeltaRouteStrategy
+ * @see Direction
+ */
+public class EnPassantRouteStrategy extends DirectionalDeltaRouteStrategy {
+  public EnPassantRouteStrategy(int width, int height, Coordinate delta, Direction direction) {
+    super(width, height, delta, direction);
+  }
+
+  /**
+   * @param from
+   * @param target
+   * @return
+   */
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    final Coordinate captureTarget = createNewTargetWithDelta(target);
+    return super.existsRelation(target, captureTarget);
+  }
+
+  /**
+   * @param from
+   * @return
+   */
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    final Set<Coordinate> answer = new TreeSet<>();
+
+    final Coordinate target = createNewTargetWithDelta(from);
+    if (verifyCoordinateIsInside(from) && verifyCoordinateIsInside(target)) {
+      answer.add(target);
+    }
+
+    return answer;
+  }
+
+  /**
+   * @param target
+   * @return
+   */
+  private Coordinate createNewTargetWithDelta(Coordinate target) {
+    return new Coordinate(target.x() + delta.x(), target.y() + direction.apply(delta.y()));
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/Movement.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/Movement.java
@@ -1,0 +1,11 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Set;
+
+public interface Movement extends RouteStrategy {
+  MovementOutcome execute(Coordinate from, Coordinate target);
+
+  boolean canCapture(Coordinate from, Coordinate target);
+
+  Set<Coordinate> calculatePossibleCaptures(Coordinate from);
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/MovementOutcome.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/MovementOutcome.java
@@ -1,0 +1,73 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.TreeSet;
+
+public class MovementOutcome {
+  private final boolean valid;
+  private final Coordinate position;
+  private final Collection<Coordinate> captures;
+
+  private MovementOutcome(boolean valid, Coordinate position, Collection<Coordinate> captures) {
+    this.valid = valid;
+    this.position = position;
+    this.captures = captures;
+  }
+
+  public static MovementOutcomeBuilder builder() {
+    return new MovementOutcomeBuilder();
+  }
+
+  public static MovementOutcome invalid() {
+    return new MovementOutcomeBuilder().executed(false).build();
+  }
+
+  public Optional<Coordinate> getPosition() {
+    return Optional.ofNullable(position);
+  }
+
+  public Collection<Coordinate> getCaptures() {
+    return Collections.unmodifiableCollection(captures);
+  }
+
+  public boolean isValid() {
+    return valid;
+  }
+
+  public static class MovementOutcomeBuilder {
+
+    private final Collection<Coordinate> captures;
+    private boolean executed;
+    private Coordinate position;
+
+    private MovementOutcomeBuilder() {
+      this.captures = new TreeSet<>();
+    }
+
+    public MovementOutcomeBuilder executed(boolean executed) {
+      this.executed = executed;
+      return this;
+    }
+
+    public MovementOutcomeBuilder position(Coordinate position) {
+      this.position = position;
+      return this;
+    }
+
+    public MovementOutcomeBuilder capture(Coordinate capture) {
+      this.captures.add(capture);
+      return this;
+    }
+
+    public MovementOutcomeBuilder capture(Collection<Coordinate> captures) {
+      this.captures.addAll(captures);
+      return this;
+    }
+
+    public MovementOutcome build() {
+      return new MovementOutcome(executed, position, captures);
+    }
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/MultipleMovementStrategy.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/MultipleMovementStrategy.java
@@ -1,0 +1,53 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.*;
+
+public class MultipleMovementStrategy implements Movement {
+  private final Collection<Movement> strategies;
+
+  public MultipleMovementStrategy(Movement... strategies) {
+    this.strategies = Arrays.asList(strategies);
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return findAnyWhichCanControl(from, target).isPresent();
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    final Set<Coordinate> answer = new TreeSet<>();
+    for (Movement delegate : strategies) {
+      answer.addAll(delegate.calculateAvailable(from));
+    }
+    return answer;
+  }
+
+  @Override
+  public MovementOutcome execute(Coordinate from, Coordinate target) {
+    final Optional<Movement> delegate = findAnyWhichCanControl(from, target);
+    return delegate.map(e -> e.execute(from, target)).orElseGet(MovementOutcome::invalid);
+  }
+
+  @Override
+  public boolean canCapture(Coordinate from, Coordinate target) {
+    return findAnyWhichCanCapture(from, target).isPresent();
+  }
+
+  @Override
+  public Set<Coordinate> calculatePossibleCaptures(Coordinate from) {
+    final Set<Coordinate> answer = new TreeSet<>();
+    for (Movement delegate : strategies) {
+      answer.addAll(delegate.calculatePossibleCaptures(from));
+    }
+    return answer;
+  }
+
+  private Optional<Movement> findAnyWhichCanControl(Coordinate from, Coordinate target) {
+    return strategies.stream().filter(i -> i.existsRelation(from, target)).findAny();
+  }
+
+  private Optional<Movement> findAnyWhichCanCapture(Coordinate from, Coordinate target) {
+    return strategies.stream().filter(i -> i.canCapture(from, target)).findAny();
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/SimplyRouteStrategy.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/SimplyRouteStrategy.java
@@ -1,0 +1,22 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class SimplyRouteStrategy implements RouteStrategy {
+  private Set<Coordinate> coordinates = Collections.emptySet();
+
+  public void setCoordinates(Set<Coordinate> coordinates) {
+    this.coordinates = coordinates;
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return coordinates.contains(target);
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    return Collections.unmodifiableSet(coordinates);
+  }
+}

--- a/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/package-info.java
+++ b/chessplayground-cdk/src/main/java/com/github/sigur/chessplayground/cdk/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 
+ */
+package com.github.sigur.chessplayground.cdk;

--- a/chessplayground-cdk/src/main/java/module-info.java
+++ b/chessplayground-cdk/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+/**
+*
+*/
+module chessplayground.cdk {}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CaptureAndMovementAdapterTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CaptureAndMovementAdapterTest.java
@@ -1,0 +1,51 @@
+package com.github.sigur.chessplayground.cdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class CaptureAndMovementAdapterTest {
+
+  @Test
+  void executeNoCapture() {
+    final RouteStrategy capture = new DummyRoute();
+    final DummyRoute movement = new DummyRoute();
+    movement.setControl(true);
+    movement.setCoordinates(Collections.singleton(new Coordinate(5, 6)));
+
+    final CaptureAndMovementAdapter move = new CaptureAndMovementAdapter(capture, movement);
+
+    final MovementOutcome actual = move.execute(new Coordinate(2, 2), new Coordinate(3, 3));
+    assertThat(actual.isValid()).isTrue();
+    assertThat(actual.getPosition()).hasValue(new Coordinate(3, 3));
+    assertThat(actual.getCaptures()).isEmpty();
+  }
+
+  @Test
+  void noCapture() {
+    final DummyRoute capture = new DummyRoute();
+    capture.setControl(false);
+    final DummyRoute movement = new DummyRoute();
+    movement.setControl(true);
+    movement.setCoordinates(Collections.singleton(new Coordinate(5, 6)));
+
+    final CaptureAndMovementAdapter move = new CaptureAndMovementAdapter(capture, movement);
+    assertThat(move.canCapture(new Coordinate(2, 2), new Coordinate(3, 3))).isFalse();
+    assertThat(move.calculatePossibleCaptures(new Coordinate(2, 2))).isEmpty();
+  }
+
+  @Test
+  void pawnEnPassant() {
+
+    final CaptureAndMovementAdapter enPassant =
+        new CaptureAndMovementAdapter(
+            new EnPassantRouteStrategy(5, 5, new Coordinate(0, 1), Direction.DESCENT),
+            new DirectionalDeltaRouteStrategy(5, 5, new Coordinate(1, 1), Direction.ASCENT));
+
+    final MovementOutcome actual = enPassant.execute(new Coordinate(2, 2), new Coordinate(3, 3));
+    assertThat(actual.isValid()).isTrue();
+    assertThat(actual.getPosition()).hasValue(new Coordinate(3, 3));
+    assertThat(actual.getCaptures()).containsExactly(new Coordinate(3, 2));
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CaptureOnTargetMovementTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CaptureOnTargetMovementTest.java
@@ -1,0 +1,106 @@
+package com.github.sigur.chessplayground.cdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+class CaptureOnTargetMovementTest {
+
+  @Test
+  void execute() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setControl(true);
+    movement.setCoordinates(Collections.singleton(new Coordinate(1, 1)));
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+    final MovementOutcome actual = move.execute(new Coordinate(0, 0), new Coordinate(1, 1));
+    assertThat(actual.isValid()).isTrue();
+    assertThat(actual.getCaptures()).containsExactly(new Coordinate(1, 1));
+    assertThat(actual.getPosition()).hasValue(new Coordinate(1, 1));
+  }
+
+  @Test
+  void pawnCalculatePossibleCaptures() {
+    final DirectionalDeltaRouteStrategy movement =
+        new DirectionalDeltaRouteStrategy(4, 4, new Coordinate(1, 1), Direction.DESCENT);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+    final Set<Coordinate> actual = move.calculatePossibleCaptures(new Coordinate(3, 3));
+    assertThat(actual).containsExactly(new Coordinate(2, 2), new Coordinate(4, 2));
+  }
+
+  @Test
+  void existsRelation() {
+    final SimplyRouteStrategy movement = new SimplyRouteStrategy();
+
+    final Set<Coordinate> valid = new TreeSet<>();
+    valid.add(new Coordinate(3, 2));
+    valid.add(new Coordinate(7, 7));
+    movement.setCoordinates(valid);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+
+    assertThat(move.existsRelation(new Coordinate(0, 0), new Coordinate(1, 1)))
+        .withFailMessage("%s should not be controlled", new Coordinate(1, 1))
+        .isFalse();
+
+    assertThat(move.existsRelation(new Coordinate(0, 0), new Coordinate(3, 2)))
+        .withFailMessage("%s should be controlled", new Coordinate(3, 2))
+        .isTrue();
+  }
+
+  @Test
+  void pawnExistsRelation() {
+    final DirectionalDeltaRouteStrategy movement =
+        new DirectionalDeltaRouteStrategy(5, 5, new Coordinate(0, 2), Direction.DESCENT);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+    assertThat(move.existsRelation(new Coordinate(3, 5), new Coordinate(3, 3)))
+        .withFailMessage(
+            "%s should be available for pawn from %s with %s as movement and %s as direction",
+            new Coordinate(3, 3), new Coordinate(3, 5), new Coordinate(0, 2), Direction.DESCENT)
+        .isTrue();
+  }
+
+  @Test
+  void calculateAvailable() {
+    final SimplyRouteStrategy movement = new SimplyRouteStrategy();
+
+    final Set<Coordinate> valid = new TreeSet<>();
+    valid.add(new Coordinate(3, 2));
+    valid.add(new Coordinate(7, 7));
+    movement.setCoordinates(valid);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+
+    assertThat(move.calculateAvailable(new Coordinate(0, 0)))
+        .containsExactlyInAnyOrder(new Coordinate(7, 7), new Coordinate(3, 2));
+  }
+
+  @Test
+  void pawnCalculateAvailable() {
+    final DirectionalDeltaRouteStrategy movement =
+        new DirectionalDeltaRouteStrategy(5, 5, new Coordinate(1, 1), Direction.DESCENT);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+    assertThat(move.calculateAvailable(new Coordinate(3, 5)))
+        .containsExactlyInAnyOrder(new Coordinate(2, 4), new Coordinate(4, 4));
+  }
+
+  @Test
+  void canCapture() {
+    final SimplyRouteStrategy movement = new SimplyRouteStrategy();
+
+    final Set<Coordinate> valid = new TreeSet<>();
+    valid.add(new Coordinate(3, 2));
+    valid.add(new Coordinate(7, 7));
+    movement.setCoordinates(valid);
+
+    final CaptureOnTargetMovement move = new CaptureOnTargetMovement(movement);
+
+    assertThat(move.canCapture(new Coordinate(1, 2), new Coordinate(7, 7))).isTrue();
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CapturelessMovementTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/CapturelessMovementTest.java
@@ -1,0 +1,86 @@
+package com.github.sigur.chessplayground.cdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class CapturelessMovementTest {
+
+  @Test
+  void calculatePossibleCaptures() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setCoordinates(Collections.singleton(new Coordinate(3, 5)));
+
+    final CapturelessMovement actual = new CapturelessMovement(movement);
+    actual.calculatePossibleCaptures(new Coordinate(3, 3)).isEmpty();
+  }
+
+  @Test
+  void executeControllable() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setCoordinates(Collections.singleton(new Coordinate(3, 5)));
+    movement.setControl(true);
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final MovementOutcome actual = move.execute(new Coordinate(3, 3), new Coordinate(3, 5));
+    assertThat(actual.isValid()).isTrue();
+    assertThat(actual.getCaptures()).isEmpty();
+    assertThat(actual.getPosition()).hasValue(new Coordinate(3, 5));
+  }
+
+  @Test
+  void executeNotControllable() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setCoordinates(Collections.singleton(new Coordinate(3, 5)));
+    movement.setControl(false);
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final MovementOutcome actual = move.execute(new Coordinate(3, 3), new Coordinate(3, 5));
+    assertThat(actual.isValid()).isFalse();
+    assertThat(actual.getCaptures()).isEmpty();
+    assertThat(actual.getPosition()).isEmpty();
+  }
+
+  @Test
+  void controllable() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setControl(true);
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final boolean actual = move.existsRelation(new Coordinate(3, 3), new Coordinate(3, 5));
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void notControllable() {
+    final DummyRoute movement = new DummyRoute();
+    movement.setControl(false);
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final boolean actual = move.existsRelation(new Coordinate(3, 3), new Coordinate(3, 5));
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void pawnMovement() {
+    final DirectionalDeltaRouteStrategy movement =
+        new DirectionalDeltaRouteStrategy(7, 7, new Coordinate(0, 1), Direction.ASCENT);
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final MovementOutcome actual = move.execute(new Coordinate(2, 3), new Coordinate(2, 4));
+    assertThat(actual.isValid()).isTrue();
+    assertThat(actual.getCaptures()).isEmpty();
+    assertThat(actual.getPosition()).hasValue(new Coordinate(2, 4));
+  }
+
+  @Test
+  void canCapture() {
+    final SimplyRouteStrategy movement = new SimplyRouteStrategy();
+    movement.setCoordinates(Collections.singleton(new Coordinate(3, 2)));
+
+    final CapturelessMovement move = new CapturelessMovement(movement);
+    final boolean actual = move.canCapture(new Coordinate(3, 2), new Coordinate(3, 2));
+    assertThat(actual).isFalse();
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/ColorTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/ColorTest.java
@@ -1,0 +1,12 @@
+package com.github.sigur.chessplayground.cdk;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ColorTest {
+  @Test
+  void opposite() {
+    Assertions.assertThat(Color.WHITE.opposite()).isEqualTo(Color.BLACK);
+    Assertions.assertThat(Color.BLACK.opposite()).isEqualTo(Color.WHITE);
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/DirectionTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/DirectionTest.java
@@ -1,0 +1,22 @@
+package com.github.sigur.chessplayground.cdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DirectionTest {
+
+  @Test
+  void opposite() {
+    assertThat(Direction.DESCENT.opposite()).isEqualTo(Direction.ASCENT);
+    assertThat(Direction.ASCENT.opposite()).isEqualTo(Direction.DESCENT);
+  }
+
+  @Test
+  void apply() {
+    assertThat(Direction.DESCENT.apply(1)).isEqualTo(-1);
+    assertThat(Direction.DESCENT.apply(-1)).isEqualTo(1);
+    assertThat(Direction.ASCENT.apply(1)).isEqualTo(1);
+    assertThat(Direction.ASCENT.apply(-1)).isEqualTo(-1);
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/DummyRoute.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/DummyRoute.java
@@ -1,0 +1,28 @@
+package com.github.sigur.chessplayground.cdk;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class DummyRoute implements RouteStrategy {
+  private Set<Coordinate> coordinates = Collections.emptySet();
+  private boolean control;
+
+  public void setCoordinates(Set<Coordinate> coordinates) {
+    this.coordinates = coordinates;
+  }
+
+
+  public void setControl(boolean control) {
+    this.control = control;
+  }
+
+  @Override
+  public boolean existsRelation(Coordinate from, Coordinate target) {
+    return control;
+  }
+
+  @Override
+  public Set<Coordinate> calculateAvailable(Coordinate from) {
+    return coordinates;
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/EnPassantRouteStrategyTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/EnPassantRouteStrategyTest.java
@@ -1,0 +1,36 @@
+package com.github.sigur.chessplayground.cdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EnPassantRouteStrategyTest {
+
+  @Test
+  void ascent() {
+    var strategy = new EnPassantRouteStrategy(5, 5, new Coordinate(0, 2), Direction.ASCENT);
+
+    assertThat(strategy.existsRelation(new Coordinate(3, 3), new Coordinate(2, 4)))
+        .withFailMessage("%s should not be available because it is outside", new Coordinate(2, 6))
+        .isFalse();
+    assertThat(strategy.existsRelation(new Coordinate(1, 1), new Coordinate(0, 2)))
+        .withFailMessage("%s should be valid", new Coordinate(0, 4))
+        .isTrue();
+    assertThat(strategy.calculateAvailable(new Coordinate(3, 3)))
+        .containsExactly(new Coordinate(3, 5));
+  }
+
+  @Test
+  void descent() {
+    var strategy = new EnPassantRouteStrategy(5, 5, new Coordinate(0, 2), Direction.DESCENT);
+
+    assertThat(strategy.existsRelation(new Coordinate(3, 3), new Coordinate(4, 4)))
+        .withFailMessage("%s should be available because it is inside", new Coordinate(2, 4))
+        .isTrue();
+    assertThat(strategy.existsRelation(new Coordinate(1, 1), new Coordinate(0, 1)))
+        .withFailMessage("%s should not be valid because it is outside", new Coordinate(0, -1))
+        .isFalse();
+    assertThat(strategy.calculateAvailable(new Coordinate(3, 3)))
+        .containsExactly(new Coordinate(3, 1));
+  }
+}

--- a/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/PawnMovementTest.java
+++ b/chessplayground-cdk/src/test/java/com/github/sigur/chessplayground/cdk/PawnMovementTest.java
@@ -1,0 +1,8 @@
+package com.github.sigur.chessplayground.cdk;
+
+
+import org.junit.jupiter.api.Test;
+
+class PawnMovementTest {
+
+}

--- a/chessplayground-engine/pom.xml
+++ b/chessplayground-engine/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.sigur.chessplayground</groupId>
+        <artifactId>chess-playground</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>chessplayground-engine</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Chess-playground - Engine</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.sigur.chessplayground</groupId>
+            <artifactId>chessplayground-cdk</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/App.java
+++ b/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/App.java
@@ -1,0 +1,13 @@
+package com.github.sigur.chessplayground;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/Hello.java
+++ b/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/Hello.java
@@ -1,0 +1,3 @@
+package com.github.sigur.chessplayground.engine;
+
+public class Hello {}

--- a/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/PieceFactory.java
+++ b/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/PieceFactory.java
@@ -1,0 +1,9 @@
+package com.github.sigur.chessplayground.engine;
+
+import com.github.sigur.chessplayground.cdk.Coordinate;
+import com.github.sigur.chessplayground.cdk.Direction;
+import com.github.sigur.chessplayground.cdk.Piece;
+
+public interface PieceFactory {
+    Piece createPawn(Coordinate position, Direction direction);
+}

--- a/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/standard/StandardChessPieceFactory.java
+++ b/chessplayground-engine/src/main/java/com/github/sigur/chessplayground/engine/standard/StandardChessPieceFactory.java
@@ -1,0 +1,41 @@
+package com.github.sigur.chessplayground.engine.standard;
+
+import com.github.sigur.chessplayground.cdk.*;
+import com.github.sigur.chessplayground.engine.PieceFactory;
+
+public class StandardChessPieceFactory implements PieceFactory {
+  private static final Coordinate ONE_STEP = new Coordinate(0, 1);
+  private static final Coordinate TWO_STEPS = new Coordinate(0, 2);
+  private static final Coordinate ZERO = new Coordinate(0, 0);
+  private static final PieceName PAWN_VALUE = PieceName.PAWN;
+  private final Coordinate size;
+  private final Color color;
+
+  public StandardChessPieceFactory(int width, int height, Color color) {
+    this.size = new Coordinate(width, height);
+    this.color = color;
+  }
+
+  @Override
+  public Piece createPawn(Coordinate position, Direction direction) {
+    final RouteStrategy pawnMovements =
+        new MultipleRouteStrategy(
+            new DirectionalDeltaRouteStrategy(size.x(), size.y(), ONE_STEP, direction),
+            new DirectionalDeltaRouteStrategy(size.x(), size.y(), TWO_STEPS, direction));
+    return Piece.builder()
+        .movement(new CapturelessMovement(pawnMovements))
+        //.attack(new PawnRouteStrategy(ZERO, size, new Coordinate(1, 1), direction))
+        .type(PAWN_VALUE)
+        .position(position)
+        .color(color)
+        .build();
+  }
+
+  public int getWidth() {
+    return size.x();
+  }
+
+  public int getHeight() {
+    return size.y();
+  }
+}


### PR DESCRIPTION
First commit. This commit adds main components to create pawn attack and pawn movements on board:
- First move (2 squares)
- Pawn move (1 square)
- En-Passant

Since it's the first commit, core design components have been pushed.